### PR TITLE
Use provided coding peptides to make test bloom filter set

### DIFF
--- a/khtools/compare_kmer_content.py
+++ b/khtools/compare_kmer_content.py
@@ -77,6 +77,18 @@ def kmerize(seq, ksize):
     return set(seq[i:i + ksize] for i in range(len(seq) - ksize + 1))
 
 
+def kmerize_ordered(seq, ksize):
+    """Return an ordered dictionary of k-mers, with their sequence location"""
+    kmers = OrderedDict()
+    for i in range(len(seq) - ksize + 1):
+        kmer = seq[i:i + ksize]
+        if kmer not in kmers:
+            kmers[kmer] = [i]
+        else:
+            kmers[kmer].append(i)
+    return kmers
+
+
 def jaccardize(set1, set2):
     """Compute jaccard index of two sets"""
     denominator = min(len(set1), len(set2))

--- a/khtools/compare_kmer_content.py
+++ b/khtools/compare_kmer_content.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from functools import partial
 import itertools
 import multiprocessing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,16 @@ def peptide_bloom_filter_path(data_folder, molecule, peptide_ksize):
 
 
 @pytest.fixture
+def coding_peptide_bloom_filter_path(data_folder, molecule, peptide_ksize):
+    filename = os.path.join(
+        data_folder, 'bloom_filter',
+        f'gencode.v32.pc_translations.subsample5.randomseed0-{molecule}_'
+        f'ksize-{peptide_ksize}.bloomfilter.nodegraph'
+    )
+    return filename
+
+
+@pytest.fixture
 def peptide_bloom_filter(peptide_bloom_filter_path, peptide_fasta, molecule,
                          peptide_ksize):
     from khtools.bloom_filter import load_nodegraph
@@ -107,11 +117,12 @@ def peptide_bloom_filter(peptide_bloom_filter_path, peptide_fasta, molecule,
 
 @pytest.fixture
 def coding_peptide_bloom_filter(
-        peptide_bloom_filter_path, coding_peptide_fasta, molecule, peptide_ksize):
+    coding_peptide_bloom_filter_path, coding_peptide_fasta, molecule,
+    peptide_ksize):
     from khtools.bloom_filter import load_nodegraph
     """Load bloom filter from path if exists, otherwise, make it"""
     try:
-        return load_nodegraph(peptide_bloom_filter_path)
+        return load_nodegraph(coding_peptide_bloom_filter_path)
     except (FileNotFoundError, OSError):
         from khtools.bloom_filter import make_peptide_bloom_filter
 
@@ -119,5 +130,5 @@ def coding_peptide_bloom_filter(
                                                  peptide_ksize,
                                                  molecule,
                                                  tablesize=1e6)
-        bloom_filter.save(peptide_bloom_filter_path)
+        bloom_filter.save(coding_peptide_bloom_filter_path)
         return bloom_filter


### PR DESCRIPTION
Hey @pranathivemuri, turns out the test bloom filter in `conftest.py` wasn't being created from the provided peptides, but rather the other subset, `tests/data/bloom_filter/Homo_sapiens.GRCh38.pep.subset.fa.gz`. This PR adds a couple functions for checking if the kmers fro ma sequence are in the bloom filter, and updates `conftest.py` to use the provided sequences